### PR TITLE
Add output types to blocks, closures and defs

### DIFF
--- a/nushell.pest
+++ b/nushell.pest
@@ -129,10 +129,12 @@ value = _{ binary_data | range | unit | float | int | string | pathed_value | "t
 
 // Code blocks
 
-block = { "{" ~ nl? ~ toplevel* ~ nl? ~ "}" }
+out_type_block = { "->" ~ ident ~ ";" }
+
+block = { "{" ~ out_type_block? ~ nl? ~ toplevel* ~ nl? ~ "}" }
 
 closure_args = { "|" ~ param* ~ "|"}
-closure = { "{" ~ closure_args ~ ("\r" | "\n")? ~ toplevel* ~ "}" }
+closure = { "{" ~ closure_args ~ out_type_block? ~ ("\r" | "\n")? ~ toplevel* ~ "}" }
 
 param = { ident ~ (":" ~ ident)? ~ ("=" ~ value)? }
 params = { ("(" ~ param* ~ ")") | ("[" ~ param* ~ "]") }
@@ -140,9 +142,11 @@ params = { ("(" ~ param* ~ ")") | ("[" ~ param* ~ "]") }
 
 // Reserved word builtins
 
+out_type_def = { "->" ~ ident }
+
 where_command = { "where" ~ row_condition }
-def_command = { "def" ~ ident ~ params ~ block }
-def_env_command = { "def-env" ~ ident ~ params ~ block }
+def_command = { "def" ~ ident ~ params ~ out_type_def? ~ block }
+def_env_command = { "def-env" ~ ident ~ params ~ out_type_def? ~ block }
 if_command = { "if" ~ expr ~ block ~ ("else" ~ if_command)* ~ ("else" ~ block)? }
 let_command = { "let" ~ ident ~ "=" ~ pipeline }
 

--- a/nushell.pest
+++ b/nushell.pest
@@ -130,7 +130,6 @@ value = _{ binary_data | range | unit | float | int | string | pathed_value | "t
 // Code blocks
 
 out_type_block = { "->" ~ ident ~ ";" }
-
 block = { "{" ~ out_type_block? ~ nl? ~ toplevel* ~ nl? ~ "}" }
 
 closure_args = { "|" ~ param* ~ "|"}
@@ -143,11 +142,12 @@ params = { ("(" ~ param* ~ ")") | ("[" ~ param* ~ "]") }
 // Reserved word builtins
 
 out_type_def = { "->" ~ ident }
+untyped_block = { "{" ~ nl? ~ toplevel* ~ nl? ~ "}" }
 
 where_command = { "where" ~ row_condition }
-def_command = { "def" ~ ident ~ params ~ out_type_def? ~ block }
-def_env_command = { "def-env" ~ ident ~ params ~ out_type_def? ~ block }
-if_command = { "if" ~ expr ~ block ~ ("else" ~ if_command)* ~ ("else" ~ block)? }
+def_command = { "def" ~ ident ~ params ~ out_type_def? ~ untyped_block }
+def_env_command = { "def-env" ~ ident ~ params ~ out_type_def? ~ untyped_block }
+if_command = { "if" ~ expr ~ untyped_block ~ ("else" ~ if_command)* ~ ("else" ~ untyped_block)? }
 let_command = { "let" ~ ident ~ "=" ~ pipeline }
 
 // Commands


### PR DESCRIPTION
After the PR, it should be able to parse (I included untyped versions to check the old ones keep working):

```
let b = {-> string; str length }
let b = { str length }

let c = {|| -> string; str length }
let c = {|| str length }

def foo [x: int] -> string {
    $x
}

def foo [x: int] {
    $x
}
```

Defining both def and block types is disallowed:
```
def foo [x: int] -> string { -> int;
    $x
}
```
(currently parses `->` and `int;` as ident and bare string)