### PR TITLE
accept newlines in more places

### DIFF
--- a/nushell.pest
+++ b/nushell.pest
@@ -14,11 +14,6 @@ float = @{
     ~ (^"e" ~ ("+" | "-")? ~ ASCII_DIGIT+)?
 }
 
-array = {
-    "[" ~ "]" |
-    "[" ~ nl? ~ bare_value ~ (","? ~ bare_value)* ~ nl? ~ "]"
-}
-
 string = { double_quote_string | single_quote_string | backtick_string | interpolation_string }
 double_quote_string = ${ "\"" ~ double_quote_string_inner ~ "\"" }
 double_quote_string_inner = @{ double_quote_string_char* }
@@ -54,8 +49,13 @@ backtick_string_char = {
 
 // Compound values
 
+array = {
+    "[" ~ "]" |
+    "[" ~ nl* ~ bare_value ~ (nl* ~ ","? ~ nl* ~ bare_value)* ~ nl* ~ "]"
+}
+
 table = {
-    "["~ nl? ~ array ~ nl? ~ ";" ~ nl? ~ (array | nl)+ ~ "]"
+    "["~ nl* ~ array ~ nl* ~ ";" ~ (array | nl)+ ~ "]"
 }
 record = {
     "{" ~ "}" |
@@ -166,7 +166,7 @@ traditional_call = ${ (ident ~ "(" ~ arg_list? ~ ")") }
 
 // Pipeline
 
-pipeline = { command ~ ((!"||" ~ "|") ~ command)* }
+pipeline = { command ~ ((!"||" ~ nl? ~ "|") ~ command)* }
 
 
 // Program


### PR DESCRIPTION
Accept more locations for newlines, which helps with parsing existing nushell code. Can now parse:

```
[[a b]; [1 2] [1 4] [2 6] [2 4]]
    | into df
    | group-by a
    | agg [
        (col b | min | as "b_min")
        (col b | max | as "b_max")
        (col b | sum | as "b_sum")
     ]
```

cc @fdncred 